### PR TITLE
0.0.70

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python_tabular"
-version = "0.0.60"
+version = "0.0.70"
 authors = [
   { name="Curtis Stallings", email="curtisrstallings@gmail.com" },
 ]

--- a/test/test_tabular.py
+++ b/test/test_tabular.py
@@ -1,11 +1,11 @@
 import pytabular
-from pytabular import localsecret
+import local as l
 import pytest
 import pandas as pd
 from Microsoft.AnalysisServices.Tabular import Database
 
-aas = pytabular.Tabular(localsecret.CONNECTION_STR['FIN 500'])
-gen2 = pytabular.Tabular(localsecret.CONNECTION_STR['GEN2TEST'])
+aas = pytabular.Tabular(l.AAS)
+gen2 = pytabular.Tabular(l.GEN2)
 testing_parameters = [(aas),(gen2)]
 testingtable = 'PyTestTable'
 


### PR DESCRIPTION
- Refactored Tabular().Refresh() to better handle partitions. 
- Removed local file from repository and calling outside to avoid reliance on .gitignore.
- Added Database.Refresh() to Tabular().ReloadInfo() to recalc estimated model size after refreshes or changes.
- Updated pytests to account for local file change.