### PR TITLE
0.2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python_tabular"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
   { name="Curtis Stallings", email="curtisrstallings@gmail.com" },
 ]

--- a/pytabular/logic_utils.py
+++ b/pytabular/logic_utils.py
@@ -175,3 +175,17 @@ def sql_wrap_count_around_query(original_query: str) -> str:
             str: f"SELECT COUNT(1) FROM ({original_query}) temp_table"
     """
     return f"SELECT COUNT(1) FROM ({original_query}) temp_table"
+
+
+def get_sub_list(lst: list, n: int) -> list:
+    """Nest list by n amount...
+    `get_sub_list([1,2,3,4,5,6],2) == [[1,2],[3,4],[5,6]]`
+
+    Args:
+        lst (list): List to nest.
+        n (int): Amount to nest list.
+
+    Returns:
+        list: Nested list.
+    """
+    return [lst[i: i + n] for i in range(0, len(lst), n)]

--- a/pytabular/object.py
+++ b/pytabular/object.py
@@ -33,7 +33,7 @@ class PyObject(ABC):
 class PyObjects:
     def __init__(self, objects) -> None:
         self._objects = objects
-        self._display = Table(title="PyObject Collection")
+        self._display = Table(title=str(self.__class__.mro()[0]))
         for index, obj in enumerate(self._objects):
             self._display.add_row(str(index), obj.Name)
 
@@ -56,8 +56,9 @@ class PyObjects:
         return len(self._objects)
 
     def Find(self, object_str):
-        return [
+        items = [
             object
             for object in self._objects
             if object_str.lower() in object.Name.lower()
         ]
+        return self.__class__.mro()[0](items)


### PR DESCRIPTION
- Using `self.__class__.mro()` to get the Parent class, maybe there is a better way? Regardless, that simple adjustment lets me wrap the `Find` method returned lists for all `PyObjects` to their respective class (PyTable, PyMeasure, PyColumn, etc.)
- Add function to utils for later use, just nests a list by x amount. Ex. `get_sub_list([1,2,3,4,5,6],2) == [[1,2],[3,4],[5,6]]`. Will use this later to experiment with multiprocessing out larger bulk queries.