### PR TITLE
0.3.6 - PEP8 Docstring Compliance

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,4 @@
 [flake8]
-ignore = E501, W503, E203
+extend-ignore=E203
+max-line-length=100
+docstring-convention=google

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -29,4 +29,5 @@ jobs:
       - run: pip install --upgrade pip
       - run: pip install flake8
       - run: pip install pep8-naming
+      - run: pip install flake8-docstrings
       - run: python3 -m flake8 --count

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [PyTabular](https://github.com/Curts0/PyTabular) (python-tabular in [pypi](https://pypi.org/project/python-tabular/)) is a python package that allows for programmatic execution on your tabular models! This is possible thanks to [Pythonnet](https://pythonnet.github.io/) and Microsoft's [.Net APIs on Azure Analysis Services](https://docs.microsoft.com/en-us/dotnet/api/microsoft.analysisservices?view=analysisservices-dotnet). Currently, this build is tested and working on Windows Operating System only. Help is needed to expand this for other operating systems. The package should have the dll files included when you import it. See [Documentation Here](https://curts0.github.io/PyTabular/). PyTabular is still considered alpha while I'm working on building out the proper tests and testing environments, so I can ensure some kind of stability in features. Please send bugs my way! Preferably in the issues section in Github. I want to harden this project so many can use it easily. I currently have local pytest for python 3.6 to 3.10 and run those tests through a local AAS and Gen2 model.
 
 ### Getting Started
-See the [Pypi project](https://pypi.org/project/python-tabular/) for available versions. **To become PEP8 compliant with naming conventions, serious name changes were made in 0.3.5.** Instal v. 0.3.4 or lower to get the older naming conventions.
+See the [Pypi project](https://pypi.org/project/python-tabular/) for available versions. **To become PEP8 compliant with naming conventions, serious name changes were made in 0.3.5.** Install v. 0.3.4 or lower to get the older naming conventions.
 ```powershell
 python3 -m pip install python-tabular
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ nav:
     - Table: Table.md
     - Partition: Partition.md
     - Column: Column.md
+    - Measure: Measure.md
     - Trace: Traces.md
     - Queries: Queries.md
     - Best Practice Analyzer: Best Practice Analyzer.md

--- a/mkgendocs.yml
+++ b/mkgendocs.yml
@@ -12,34 +12,92 @@ pages:
   - page: "Queries.md"
     source: 'pytabular/query.py'
     classes:
-      - Connection
+      - Connection:
+        - __init__
+        - query
   - page: "Refreshes.md"
     source: 'pytabular/refresh.py'
     classes:
-      - PyRefresh
-      - RefreshCheck
+      - PyRefresh:
+        - __init__
+        - _pre_checks
+        - _post_checks
+        - _get_trace
+        - _find_table
+        - _find_partition
+        - _refresh_table
+        - _refresh_partition
+        - _refresh_dict
+        - _request_refresh
+        - run
+      - RefreshCheck:
+        - __init__
+        - pre_check
+        - post_check
+        - assertion_run
       - RefreshCheckCollection
   - page: "Table.md"
     source: 'pytabular/table.py'
     classes:
-      - PyTable
-      - PyTables
+      - PyTable:
+        - __init__
+        - row_count
+        - refresh
+        - last_refresh
+        - related
+      - PyTables:
+        - __init__
+        - refresh
+        - query_all
+        - find_zero_rows
+        - last_refresh
   - page: "Partition.md"
     source: 'pytabular/partition.py'
     classes:
-      - PyPartition
-      - PyPartitions
+      - PyPartition:
+        - __init__
+        - last_refresh
+        - refresh
+      - PyPartitions:
+        - __init__
   - page: "Column.md"
     source: 'pytabular/column.py'
     classes:
-      - PyColumn
-      - PyColumns
+      - PyColumn:
+        - __init__
+        - get_dependencies
+        - get_sample_values
+        - distinct_count
+        - values
+      - PyColumns:
+        - __init__
+        - query_all
+  - page: "Measure.md"
+    source: 'pytabular/measure.py'
+    classes:
+      - PyMeasure:
+        - __init__
+        - get_dependencies
+      - PyMeasures:
+        - __init__
   - page: "Traces.md"
     source: 'pytabular/tabular_tracing.py'
     classes:
-      - BaseTrace
-      - RefreshTrace
-      - QueryMonitor
+      - BaseTrace:
+        - __init__
+        - build
+        - add
+        - update
+        - start
+        - stop
+        - drop
+      - RefreshTrace:
+        - __init__
+      - QueryMonitor:
+        - __init__
+    functions:
+      - _refresh_handler
+      - _query_monitor_handler
   - page: "Best Practice Analyzer.md"
     source: 'pytabular/best_practice_analyzer.py'
     functions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python_tabular"
-version = "0.3.5"
+version = "0.3.6"
 authors = [
   { name="Curtis Stallings", email="curtisrstallings@gmail.com" },
 ]

--- a/pytabular/__init__.py
+++ b/pytabular/__init__.py
@@ -1,5 +1,5 @@
-"""
-Welcome to PyTabular.
+"""Welcome to PyTabular.
+
 __init__.py will start to setup the basics.
 It will setup logging and make sure Pythonnet is good to go.
 Then it will begin to import specifics of the module.
@@ -33,9 +33,24 @@ logger.info("See https://docs.python.org/3/library/logging.html#logging-levels")
 
 logger.info(f"Python Version::{sys.version}")
 logger.info(f"Python Location::{sys.exec_prefix}")
-logger.info(f"Package Location::{__file__}")
-logger.info(f"Working Directory::{os.getcwd()}")
-logger.info(f"Platform::{sys.platform}-{platform.release()}")
+
+
+def find_version():
+    version_str = "\nversion = "
+    with open("pyproject.toml", "r") as f:
+        pyproject_text = f.read()
+    start = pyproject_text.find(version_str) + len(version_str)
+    end = pyproject_text.find("\n", start)
+    return pyproject_text[start:end].replace('"', "")
+
+
+try:
+    logger.info(f"PyTabular Version:: {find_version()}")
+except Exception:
+    logger.warning("Unable to find PyTabular Version")
+logger.info(f"Package Location:: {__file__}")
+logger.info(f"Working Directory:: {os.getcwd()}")
+logger.info(f"Platform:: {sys.platform}-{platform.release()}")
 
 dll = os.path.join(os.path.dirname(__file__), "dll")
 sys.path.append(dll)

--- a/pytabular/__init__.py
+++ b/pytabular/__init__.py
@@ -35,7 +35,12 @@ logger.info(f"Python Version::{sys.version}")
 logger.info(f"Python Location::{sys.exec_prefix}")
 
 
-def find_version():
+def find_version() -> str:
+    """Finds PyTabular version.
+
+    Returns:
+        str: Version as string.
+    """
     version_str = "\nversion = "
     with open("pyproject.toml", "r") as f:
         pyproject_text = f.read()

--- a/pytabular/best_practice_analyzer.py
+++ b/pytabular/best_practice_analyzer.py
@@ -1,9 +1,8 @@
-"""
-best_practice_analyzer is currently just a POC.
-You can call the BPA class to download or specify your own BPA file.
+"""This is currently just a POC. Handle all BPA related items.
+
+You can call the `BPA()` class to download or specify your own BPA file.
 It is used with tabular_editor.py to run BPA.
-I did not want to re-invent the wheel,
-so just letting TE2 work it's magic.
+I did not want to re-invent the wheel, so just letting TE2 work it's magic.
 """
 import logging
 import requests as r
@@ -17,19 +16,27 @@ logger = logging.getLogger("PyTabular")
 
 
 def download_bpa_file(
-    download_location: str = "https://raw.githubusercontent.com/microsoft/Analysis-Services/master/BestPracticeRules/BPARules.json",
+    download_location: str = (
+        "https://raw.githubusercontent.com/microsoft/Analysis-Services/master/BestPracticeRules/BPARules.json"  # noqa: E501
+    ),
     folder: str = "Best_Practice_Analyzer",
     auto_remove=True,
 ) -> str:
-    """Runs a request.get() to retrieve the json file from web. Will return and store in directory. Will also register the removal of the new directory and file when exiting program.
+    """Download a BPA file from local or web.
+
+    Runs a request.get() to retrieve the json file from web.
+    Will return and store in directory.
+    Will also register the removal of the new directory and file when exiting program.
 
     Args:
-            Download_Location (_type_, optional): F. Defaults to [Microsoft GitHub BPA]'https://raw.githubusercontent.com/microsoft/Analysis-Services/master/BestPracticeRules/BPARules.json'.
-            Folder (str, optional): New Folder String. Defaults to 'Best_Practice_Analyzer'.
-            Auto_Remove (bool, optional): If you wish to Auto Remove when script exits. Defaults to True.
+            download_location (str, optional):  Defaults to
+                [BPA]'https://raw.githubusercontent.com/microsoft/Analysis-Services/master/BestPracticeRules/BPARules.json'.
+            folder (str, optional): New folder string.
+                Defaults to 'Best_Practice_Analyzer'.
+            auto_remove (bool, optional): Auto Remove when script exits. Defaults to True.
 
     Returns:
-            str: File Path for the newly downloaded BPA.
+            str: File path for the newly downloaded BPA.
     """
     logger.info(f"Downloading BPA from {download_location}")
     folder_location = os.path.join(os.getcwd(), folder)
@@ -51,9 +58,12 @@ class BPA:
     def __init__(self, file_path: str = "Default") -> None:
         """BPA class to be used with the TE2 class.
 
+        You can create the BPA class without any arguments.
+        This doesn't do much right now...
+        BPA().location is where the file path is stored.
+
         Args:
-            File_Path (str, optional): See `Download_BPA_File()`. Defaults to "Default".
-            If "Default, then will run `Download_BPA_File()` without args.
+            file_path (str, optional): See `Download_BPA_File()`. Defaults to "Default".
         """
         logger.debug(f"Initializing BPA Class:: {file_path}")
         if file_path == "Default":

--- a/pytabular/culture.py
+++ b/pytabular/culture.py
@@ -1,5 +1,4 @@
-"""`culture.py` is used to house the `PyCulture`, `PyCultures`, and `PyObjectTranslations` classes.
-"""
+"""`culture.py` is used to house the `PyCulture`, and `PyCultures` classes."""
 import logging
 from object import PyObject, PyObjects
 from typing import List
@@ -8,23 +7,17 @@ logger = logging.getLogger("PyTabular")
 
 
 class PyCulture(PyObject):
-    """Wrapper for [Cultures](https://learn.microsoft.com/en-us/dotnet/api/microsoft.analysisservices.tabular.culture?view=analysisservices-dotnet).
-
-    Args:
-        Table: Parent Table to the Object Translations
-    """
+    """Main class to interact with cultures in model."""
 
     def __init__(self, object, model) -> None:
+        """Mostly extends from `PyObject`. But will add rows to `rich`."""
         super().__init__(object)
         self.Model = model
         self._display.add_row("Culture Name", self._object.Name)
         self.ObjectTranslations = self.set_translation()
 
     def set_translation(self) -> List[dict]:
-        """
-        Based on the culture, it creates a list of dicts
-        with all the available translations in the file.
-        """
+        """Based on the culture, it creates a list of dicts with available translations."""
         return [
             {
                 "object_translation": translation.Value,
@@ -38,8 +31,8 @@ class PyCulture(PyObject):
     def get_translation(
         self, object_name: str, object_parent_name: str, object_type: str = "Caption"
     ) -> dict:
-        """
-        Get Translation makes it possible to seach a specific translation of an object.
+        """Get Translation makes it possible to seach a specific translation of an object.
+
         By default it will search for the "Caption" object type, due to fact that a
         Display folder and Description can also have translations.
         """
@@ -61,4 +54,5 @@ class PyCultures(PyObjects):
     """Houses grouping of `PyCulture`."""
 
     def __init__(self, objects) -> None:
+        """Extends `PyObjects` class."""
         super().__init__(objects)

--- a/pytabular/document.py
+++ b/pytabular/document.py
@@ -1,6 +1,6 @@
-"""
-`document.py` is where a specific part of pytabular start. This module can
-generate pages in markdown for use in Docusaurus.
+"""`document.py` is where a specific part of pytabular start.
+
+This module can generate pages in markdown for use in Docusaurus.
 """
 import logging
 
@@ -17,11 +17,10 @@ logger = logging.getLogger("PyTabular")
 
 
 class ModelDocumenter:
-    """
-    The ModelDocumenter class can generate documentation based on the
-    tabular object model and it will generate it suitable for docusaurus.
+    """The ModelDocumenter class can generate documentation.
 
-    TODO: Add a General Pages template with Roles and RLS Expressions
+    This is based on the tabular object model and it will generate it suitable for docusaurus.
+    TODO: Add a General Pages template with Roles and RLS Expressions.
     TODO: Create a Sub Page per table for all columns, instead of one big page?
     TODO: Add Depencies per Measure with correct links.
     """
@@ -37,6 +36,28 @@ class ModelDocumenter:
         column_page_url: str = "4-columns.md",
         roles_page_url: str = "5-roles.md",
     ):
+        """Init will set attributes based on arguments given.
+
+        See `generate_documentation_pages()` and `save_documentation()`
+        for info on how to execute and retrieve documentation.
+
+        Args:
+            model (Tabular): Main `Tabular()` class to pull metadata from for documentation.
+            friendly_name (str, optional): Replaces the model name to a friendly string,
+                so it can be used in an URL. Defaults to `str()`.
+            save_location (str, optional): The save location where the files will be stored.
+                Defaults to "docs".
+            general_page_url (str, optional): Name of the `md` file for general information.
+                Defaults to "1-general-information.md".
+            measure_page_url (str, optional): Name of the `md` file for measures.
+                Defaults to "2-measures.md".
+            table_page_url (str, optional): Name of the `md` file for tables.
+                Defaults to "3-tables.md".
+            column_page_url (str, optional): Name of the `md` file for columns.
+                Defaults to "4-columns.md".
+            roles_page_url (str, optional): Name of the `md` file for roles.
+                Defaults to "5-roles.md".
+        """
         self.model = model
         self.model_name = friendly_name or model.Catalog or model.Database.Name
         self.friendly_name: str = str()
@@ -70,9 +91,9 @@ class ModelDocumenter:
         self.save_path = self.set_save_path()
 
     def create_object_reference(self, object: str, object_parent: str) -> str:
-        """
-        Create a Custom ID for link sections in the docs.
-        :This is based on the technical names in the model,
+        """Create a Custom ID for link sections in the docs.
+
+        This is based on the technical names in the model,
         so not the once in the translations. This makes it
         possible to link based on dependencies.
         """
@@ -80,20 +101,14 @@ class ModelDocumenter:
         return f"{{#{url_reference}}}"
 
     def generate_documentation_pages(self) -> None:
-        """
-        Generate Documentation for each specific part of the model.
-        """
+        """Generate Documentation for each specific part of the model."""
         self.measure_page = self.generate_markdown_measure_page()
         self.table_page = self.generate_markdown_table_page()
         self.column_page = self.generate_markdown_column_page()
         self.category_page = self.generate_category_file()
 
     def get_object_caption(self, object_name: str, object_parent: str):
-        """
-        Retrieves the caption of an object, based on the translations
-        in the culture.
-        """
-
+        """Retrieves the caption of an object, based on the translations in the culture."""
         if self.culture_include:
             return self.culture_object.get_translation(
                 object_name=object_name, object_parent_name=object_parent
@@ -104,10 +119,7 @@ class ModelDocumenter:
     def set_translations(
         self, enable_translations: bool = False, culture: str = "en-US"
     ) -> None:
-        """
-        Set translations to active or inactive, depending on the needs of the users.
-        """
-
+        """Set translations to active or inactive, depending on the needs of the users."""
         logger.info(f"Using Translations set to > {enable_translations}")
 
         if enable_translations:
@@ -127,24 +139,20 @@ class ModelDocumenter:
             self.culture_include = enable_translations
 
     def set_model_friendly_name(self):
-        """
-        Replaces the model name to a friendly string,
-        so it can be used in an URL.
-        """
+        """Replaces the model name to a friendly string, so it can be used in an URL."""
         return (self.model_name).replace(" ", "-").replace("_", "-").lower()
 
     def set_save_path(self) -> Path:
-        """
-        Set the location of the documentation
-        """
+        """Set the location of the documentation."""
         return Path(f"{self.save_location}/{self.friendly_name}")
 
     def save_page(self, content: str, page_name: str, keep_file: bool = False) -> None:
-        """Save the content of the documentation to a file, based on
-            the class setup.
-                - Save Location
-                - Model Friendly Name
-                - Page to be written
+        """Save the content of the documentation to a file.
+
+        Based on the class setup.
+        - Save Location
+        - Model Friendly Name
+        - Page to be written
 
         Args:
             content (str): File content to write to file.
@@ -154,7 +162,6 @@ class ModelDocumenter:
 
         Returns:
             None
-
         """
         target_file = self.save_path / page_name
 
@@ -168,18 +175,19 @@ class ModelDocumenter:
                 f.close()
 
     def save_documentation(self) -> None:
-        """Generate documentation of the model, based on the meta-data
-            in the model definitions. This first checks if the folder
-            exists, and then starts to export the files that are needed
-            for the documentatation.
-                - General Information Page -> Free format page to create.
-                - Measure Page -> Describes the measures in the model. (Incl. OLS?)
-                - Tables Page -> Describes the tables in the model. (Incl. OLS?)
-                - Columns Page -> Describes all columns in the model. (Incl. OLS?)
-                - Roles Page -> Describes the roles in the model, (incl. RLS?)
+        """Generate documentation of the model, based on the meta-data in the model definitions.
+
+        This first checks if the folder exists,
+        and then starts to export the files that are needed
+        for the documentatation.
+        - General Information Page -> Free format page to create.
+        - Measure Page -> Describes the measures in the model. (Incl. OLS?)
+        - Tables Page -> Describes the tables in the model. (Incl. OLS?)
+        - Columns Page -> Describes all columns in the model. (Incl. OLS?)
+        - Roles Page -> Describes the roles in the model, (incl. RLS?)
 
         Args:
-            self (Docs): Model object for documentation.
+            self (ModelDocumenter): Model object for documentation.
 
         Returns:
             None
@@ -232,9 +240,9 @@ class ModelDocumenter:
             )
 
     def create_markdown_for_measure(self, object: PyMeasure) -> str:
-        """
-        Create Markdown for a specific measure, that can later on be used
-        for generating the whole measure page.
+        """Create Markdown for a specific measure.
+
+        That can later on be used for generating the whole measure page.
         """
         object_caption = (
             self.get_object_caption(
@@ -278,16 +286,15 @@ class ModelDocumenter:
 """
 
     def generate_markdown_measure_page(self) -> str:
-        """
-        Based on the measure objects it generates a page based on
-        the docusaurus notation for markdown pages.
-        """
+        """Based on the measure objects it generates a measure page."""
         prev_display_folder = ""
         markdown_template = [
             f"""---
 sidebar_position: 3
 title: Measures
-description: This page contains all measures for the {self.model.Name} model, including the description, format string, and other technical details.
+description: This page contains all measures for the {self.model.Name} model, \
+including the description, \
+format string, and other technical details.
 ---
 
 # Measures for {self.model.Name}
@@ -312,15 +319,13 @@ description: This page contains all measures for the {self.model.Name} model, in
         return "".join(markdown_template)
 
     def create_markdown_for_table(self, object: PyTable) -> str:
-        """
-        This functions returns the markdwon that can be used
-        for the documentation page for Tables.
+        """This functions returns the markdown for a table.
 
         Args:
-            object: PyTable -> Based on the PyTabular Package.
+            object (PyTable): Based on the PyTabular Package.
 
         Returns:
-            Markdown text: str -> Will be append to the page text.
+            str: Will be appended to the page text.
         """
         object_caption = (
             self.get_object_caption(
@@ -385,13 +390,13 @@ description: This page contains all measures for the {self.model.Name} model, in
 """
 
     def generate_markdown_table_page(self) -> str:
-        """
-        This function generates the markdown tables documentation for the tables in the Model.
-        """
+        """This function generates the markdown tables documentation for the tables in the Model."""
         markdown_template = f"""---
 sidebar_position: 2
 title: Tables
-description: This page contains all columns with tables for {self.model.Name}, including the description, and technical details.
+description: This page contains all columns with tables for {self.model.Name}, \
+including the description, \
+and technical details.
 ---
 
 # Tables {self.model.Name}
@@ -404,13 +409,12 @@ description: This page contains all columns with tables for {self.model.Name}, i
         return markdown_template
 
     def generate_markdown_column_page(self) -> str:
-        """
-        This function generates the markdown for documentation about columns in the Model.
-        """
+        """This function generates the markdown for documentation about columns in the Model."""
         markdown_template = f"""---
 sidebar_position: 4
 title: Columns
-description: This page contains all columns with Columns for {self.model.Name}, including the description, format string, and other technical details.
+description: This page contains all columns with Columns for {self.model.Name}, \
+including the description, format string, and other technical details.
 ---
 
     """
@@ -429,8 +433,8 @@ description: This page contains all columns with Columns for {self.model.Name}, 
         return markdown_template
 
     def create_markdown_for_column(self, object: PyColumn) -> str:
-        """
-        Generates the Markdown for a specifc column.
+        """Generates the Markdown for a specifc column.
+
         If a colums is calculated, then it also shows
         the expression for that column in DAX.
         """
@@ -446,7 +450,10 @@ description: This page contains all columns with Columns for {self.model.Name}, 
         )
 
         basic_info = f"""
-### {object_caption} {self.create_object_reference(object=object.Name, object_parent=object.Parent.Name)}
+### {object_caption} {self.create_object_reference(
+        object=object.Name,
+        object_parent=object.Parent.Name
+        )}
 **Description**:
 > {object_description}
 
@@ -494,9 +501,9 @@ description: This page contains all columns with Columns for {self.model.Name}, 
         )
 
     def generate_category_file(self):
-        """
-        Docusaurs can generate an index. The category yaml will
-        make that happen.
+        """Docusaurs can generate an index.
+
+        The category yaml will make that happen.
         """
         return f"""position: 2 # float position is supported
 label: '{self.model_name}'

--- a/pytabular/logic_utils.py
+++ b/pytabular/logic_utils.py
@@ -1,5 +1,4 @@
-"""`logic_utils` used to store multiple functions that are used in many different files.
-"""
+"""`logic_utils` used to store multiple functions that are used in many different files."""
 import logging
 import datetime
 import os
@@ -12,25 +11,34 @@ logger = logging.getLogger("PyTabular")
 
 
 def ticks_to_datetime(ticks: int) -> datetime.datetime:
-    """Converts a C# System DateTime Tick into a Python DateTime
+    """Converts a C# system datetime tick into a python datatime.
 
     Args:
-            ticks (int): [C# DateTime Tick](https://docs.microsoft.com/en-us/dotnet/api/system.datetime.ticks?view=net-6.0)
+            ticks (int): C# DateTime Tick.
 
     Returns:
-            datetime.datetime: [datetime.datetime](https://docs.python.org/3/library/datetime.html)
+            datetime.datetime: datetime of tick.
     """
     return datetime.datetime(1, 1, 1) + datetime.timedelta(microseconds=ticks // 10)
 
 
 def pandas_datatype_to_tabular_datatype(df: pd.DataFrame) -> Dict:
-    """WiP takes dataframe columns and gets respective tabular column datatype.  ([NumPy Datatypes](https://numpy.org/doc/stable/reference/generated/numpy.dtype.kind.html) and [Tabular Datatypes](https://docs.microsoft.com/en-us/dotnet/api/microsoft.analysisservices.tabular.datatype?view=analysisservices-dotnet))
+    """Takes dataframe columns and gets respective tabular column datatype.
 
     Args:
             df (pd.DataFrame): Pandas DataFrame
 
     Returns:
-            Dict: EX {'col1': <Microsoft.AnalysisServices.Tabular.DataType object at 0x0000023BFFBC9700>, 'col2': <Microsoft.AnalysisServices.Tabular.DataType object at 0x0000023BFFBC8840>, 'col3': <Microsoft.AnalysisServices.Tabular.DataType object at 0x0000023BFFBC9800>}
+            Dict: dictionary with results.
+
+    Example:
+        ```
+        {
+            'col1': <Microsoft.AnalysisServices.Tabular.DataType object at 0x0000023BFFBC9700>,
+            'col2': <Microsoft.AnalysisServices.Tabular.DataType object at 0x0000023BFFBC8840>,
+            'col3': <Microsoft.AnalysisServices.Tabular.DataType object at 0x0000023BFFBC9800>
+        }
+        ```
     """
     logger.info("Getting DF Column Dtypes to Tabular Dtypes...")
     tabular_datatype_mapping_key = {
@@ -53,37 +61,36 @@ def pandas_datatype_to_tabular_datatype(df: pd.DataFrame) -> Dict:
 
 
 def pd_dataframe_to_m_expression(df: pd.DataFrame) -> str:
-    """This will take a pandas dataframe and convert to an m expression
-    For example this DF:
-       col1  col2
-    0   1     3
-    1   2     4
-
-    |
-    |
-    V
-
-    Will convert to this expression string:
-    let
-    Source=#table({"col1","col2"},
-    {
-    {"1","3"},{"2","4"}
-    })
-    in
-    Source
+    """This will take a pandas dataframe and convert to an m expression.
 
     Args:
             df (pd.DataFrame): Pandas DataFrame
 
     Returns:
             str: Currently only returning string values in your tabular model.
+
+    Example:
+        ```
+        col1  col2
+        0   1     3
+        1   2     4
+        ```
+        converts to
+        ```
+        Source=#table({"col1","col2"},
+        {
+        {"1","3"},{"2","4"}
+        })
+        in
+        Source
+        ```
     """
 
     def m_list_expression_generator(list_of_strings: List[str]) -> str:
-        """
-        Takes a python list of strings and converts to power query m expression list format...
-        Ex: ["item1","item2","item3"] --> {"item1","item2","item3"}
-        Codepoint reference --> \u007b == { and \u007d == }
+        """Takes a python list of strings and converts to power query m expression list format.
+
+        Ex: `["item1","item2","item3"]` --> `{"item1","item2","item3"}`
+        Codepoint reference --> `\u007b` == `{` and `\u007d` == `}`
         """
         string_components = ",".join(
             [f'"{string_value}"' for string_value in list_of_strings]
@@ -128,15 +135,16 @@ def remove_file(file_path):
 
 
 def remove_suffix(input_string, suffix):
-    """Adding for >3.9 compatiblity. [Stackoverflow Answer](https://stackoverflow.com/questions/66683630/removesuffix-returns-error-str-object-has-no-attribute-removesuffix)
+    """Adding for <3.9 compatiblity.
 
     Args:
-            input_string (str): input string to remove suffix from
-            suffix (str): suffix to be removed
+            input_string (str): input string to remove suffix from.
+            suffix (str): suffix to be removed.
 
     Returns:
-            str: input_str with suffix removed
+            str: input_str with suffix removed.
     """
+    # [Stackoverflow Answer](https://stackoverflow.com/questions/66683630/removesuffix-returns-error-str-object-has-no-attribute-removesuffix)  # noqa: E501
     output = (
         input_string[: -len(suffix)]
         if suffix and input_string.endswith(suffix)
@@ -146,8 +154,7 @@ def remove_suffix(input_string, suffix):
 
 
 def get_sub_list(lst: list, n: int) -> list:
-    """Nest list by n amount...
-    `get_sub_list([1,2,3,4,5,6],2) == [[1,2],[3,4],[5,6]]`
+    """Nest list by n amount.
 
     Args:
         lst (list): List to nest.
@@ -155,17 +162,19 @@ def get_sub_list(lst: list, n: int) -> list:
 
     Returns:
         list: Nested list.
+    Example:
+        `get_sub_list([1,2,3,4,5,6],2) == [[1,2],[3,4],[5,6]]`
     """
     return [lst[i : i + n] for i in range(0, len(lst), n)]
 
 
 def get_value_to_df(query: AdomdDataReader, index: int):
-    """Gets the values from the AdomdDataReader to convert the .Net Object
-    into a tangible python value to work with in pandas.
+    """Gets the values from the AdomdDataReader to convert to python df.
+
     Lots of room for improvement on this one.
 
     Args:
-        Query (AdomdDataReader): [AdomdDataReader](https://learn.microsoft.com/en-us/dotnet/api/microsoft.analysisservices.adomdclient.adomddatareader?view=analysisservices-dotnet)
+        query (AdomdDataReader): The AdomdDataReader .Net object.
         index (int): Index of the value to perform the logic on.
     """
     if (
@@ -178,9 +187,10 @@ def get_value_to_df(query: AdomdDataReader, index: int):
 
 
 def dataframe_to_dict(df: pd.DataFrame) -> List[dict]:
-    """Convert to Dataframe to dictionary and alter columns names with;
-    - Underscores (_) to spaces
-    - All Strings are converted to Title Case.
+    """Convert to Dataframe to dictionary and alter columns names with it.
+
+    Will convert the underscores (_) to spaces,
+    and all strings are converted to Title Case.
 
     Args:
         df (pd.DataFrame): Original table that needs to be converted
@@ -197,8 +207,8 @@ def dataframe_to_dict(df: pd.DataFrame) -> List[dict]:
 
 
 def dict_to_markdown_table(list_of_dicts: list, columns_to_include: list = None) -> str:
-    """
-    Description: Generate a Markdown table based on a list of dictionaries.
+    """Generate a Markdown table based on a list of dictionaries.
+
     Args:
         list_of_dicts (list): List of Dictionaries that need to be converted
             to a markdown table.
@@ -209,16 +219,18 @@ def dict_to_markdown_table(list_of_dicts: list, columns_to_include: list = None)
         String that will represent a table in Markdown.
 
     Example:
-        columns = ['Referenced Object Type', 'Referenced Table', 'Referenced Object']
-        dict_to_markdown_table(dependancies, columns)
-
-    Result:
-        | Referenced Object Type | Referenced Table | Referenced Object               |
-        | ---------------------- | ---------------- | ------------------------------- |
-        | TABLE                  | Cases            | Cases                           |
-        | COLUMN                 | Cases            | IsClosed                        |
-        | CALC_COLUMN            | Cases            | Resolution Time (Working Hours) |
-
+        ```python
+            columns = ['Referenced Object Type', 'Referenced Table', 'Referenced Object']
+            dict_to_markdown_table(dependancies, columns)
+        ```
+        Returns:
+        ```
+            | Referenced Object Type | Referenced Table | Referenced Object               |
+            | ---------------------- | ---------------- | ------------------------------- |
+            | TABLE                  | Cases            | Cases                           |
+            | COLUMN                 | Cases            | IsClosed                        |
+            | CALC_COLUMN            | Cases            | Resolution Time (Working Hours) |
+        ```
     """
     keys = set().union(*[set(d.keys()) for d in list_of_dicts])
 

--- a/pytabular/measure.py
+++ b/pytabular/measure.py
@@ -1,6 +1,7 @@
-"""
-`measure.py` houses the main `PyMeasure` and `PyMeasures` class.
-Once connected to your model, interacting with measure(s) will be done through these classes.
+"""`measure.py` houses the main `PyMeasure` and `PyMeasures` class.
+
+Once connected to your model, interacting with measure(s)
+will be done through these classes.
 """
 import logging
 import pandas as pd
@@ -10,14 +11,21 @@ logger = logging.getLogger("PyTabular")
 
 
 class PyMeasure(PyObject):
-    """Wrapper for [Microsoft.AnalysisServices.Measure](https://learn.microsoft.com/en-us/dotnet/api/microsoft.analysisservices.tabular.measure?view=analysisservices-dotnet).
-    With a few other bells and whistles added to it. WIP
+    """Main class for interacting with measures.
 
-    Args:
-        Table: Parent Table to the Measure
+    See methods for available functionality.
     """
 
     def __init__(self, object, table) -> None:
+        """Connects measure to parent `PyTable`.
+
+        It will also add some custom rows for the `rich`
+        table display.
+
+        Args:
+            object: The .Net measure object.
+            table (PyTable): The parent `PyTable`.
+        """
         super().__init__(object)
 
         self.Table = table
@@ -28,6 +36,7 @@ class PyMeasure(PyObject):
 
     def get_dependencies(self) -> pd.DataFrame:
         """Returns the dependant objects of a measure.
+
         Args:
             self: The Measure Object
 
@@ -37,18 +46,22 @@ class PyMeasure(PyObject):
                             of the object.
 
         """
-        dmv_query = f"select * from $SYSTEM.DISCOVER_CALC_DEPENDENCY where [OBJECT] = '{self.Name}' and [TABLE] = '{self.Table.Name}'"
+        dmv_query = f"select * from $SYSTEM.DISCOVER_CALC_DEPENDENCY where \
+            [OBJECT] = '{self.Name}' and [TABLE] = '{self.Table.Name}'"
         return self.Table.Model.query(dmv_query)
 
 
 class PyMeasures(PyObjects):
-    """
-    Groups together multiple measures. See `PyObjects` class for what more it can do.
+    """Groups together multiple measures.
+
+    See `PyObjects` class for what more it can do.
     You can interact with `PyMeasures` straight from model. For ex: `model.Measures`.
     Or through individual tables `model.Tables[TABLE_NAME].Measures`.
-    You can even filter down with `.Find()`. For example find all measures with `ratio` in name.
-    `model.Measures.Find('ratio')`.
+    You can even filter down with `.find()`.
+    For example find all measures with `ratio` in name.
+    `model.Measures.find('ratio')`.
     """
 
     def __init__(self, objects) -> None:
+        """Extends init from `PyObjects`."""
         super().__init__(objects)

--- a/pytabular/object.py
+++ b/pytabular/object.py
@@ -1,5 +1,5 @@
-"""
-`object.py` stores the main parent classes `PyObject` and `PyObjects`.
+"""`object.py` stores the main parent classes `PyObject` and `PyObjects`.
+
 These classes are used with the others (Tables, Columns, Measures, Partitions, etc.).
 """
 from abc import ABC
@@ -10,6 +10,7 @@ from collections.abc import Iterable
 
 class PyObject(ABC):
     """The main parent class for your (Tables, Columns, Measures, Partitions, etc.).
+
     Notice the magic methods. `__rich_repr__()` starts the baseline for displaying your model.
     It uses the amazing `rich` python package and
     builds your display from the `self._display`.
@@ -18,6 +19,16 @@ class PyObject(ABC):
     """
 
     def __init__(self, object) -> None:
+        """Init to create your PyObject.
+
+        This will take the `object` and
+        set as an attribute to the `self._object`.
+        You can use that if you want to interact directly with the .Net object.
+        It will also begin to build out a default `rich` table display.
+
+        Args:
+            object: A .Net object.
+        """
         self._object = object
         self._display = Table(title=self.Name)
         self._display.add_column(
@@ -36,17 +47,17 @@ class PyObject(ABC):
             )
 
     def __rich_repr__(self) -> str:
-        """See [Rich Repr Protocol](https://rich.readthedocs.io/en/stable/pretty.html#rich-repr-protocol)"""
+        """See [Rich Repr](https://rich.readthedocs.io/en/stable/pretty.html#rich-repr-protocol)."""
         Console().print(self._display)
 
     def __getattr__(self, attr):
-        """Searches in `self._object`"""
+        """Searches in `self._object`."""
         return getattr(self._object, attr)
 
 
 class PyObjects:
-    """
-    The main parent class for grouping your (Tables, Columns, Measures, Partitions, etc.).
+    """The main parent class for grouping your (Tables, Columns, Measures, Partitions, etc.).
+
     Notice the magic methods. `__rich_repr__()` starts the baseline for displaying your model.
     It uses the amazing `rich` python package and
     builds your display from the `self._display`.
@@ -54,17 +65,28 @@ class PyObjects:
     """
 
     def __init__(self, objects) -> None:
+        """Initialization of `PyObjects`.
+
+        Takes the objects in something that is iterable.
+        Then will build a default `rich` table display.
+
+        Args:
+            objects (_type_): _description_
+        """
         self._objects = objects
         self._display = Table(title=str(self.__class__.mro()[0]))
         for index, obj in enumerate(self._objects):
             self._display.add_row(str(index), obj.Name)
 
     def __rich_repr__(self) -> str:
-        """See [Rich Repr Protocol](https://rich.readthedocs.io/en/stable/pretty.html#rich-repr-protocol)"""
+        """See [Rich Repr](https://rich.readthedocs.io/en/stable/pretty.html#rich-repr-protocol)."""
         Console().print(self._display)
 
     def __getitem__(self, object):
-        """Checks if item is str or int. If string will iterate through and try to find matching name.
+        """Get item from `PyObjects`.
+
+        Checks if item is str or int.
+        If string will iterate through and try to find matching name.
         Otherwise, will call into `self._objects[int]` to retrieve item.
         """
         if isinstance(object, str):
@@ -75,11 +97,11 @@ class PyObjects:
             return self._objects[object]
 
     def __iter__(self):
-        """Default `__iter__()` to iterate through `PyObjects`."""
+        """Iterate through `PyObjects`."""
         yield from self._objects
 
     def __len__(self) -> int:
-        """Default `__len__()`
+        """Get length of `PyObjects`.
 
         Returns:
             int: Number of PyObject in PyObjects
@@ -87,8 +109,8 @@ class PyObjects:
         return len(self._objects)
 
     def __iadd__(self, obj):
-        """
-        Add a `PyObject` or `PyObjects` to your current `PyObjects` class.
+        """Add a `PyObject` or `PyObjects` to your current `PyObjects` class.
+
         This is useful for building out a custom `PyObjects` class to work with.
         """
         if isinstance(obj, Iterable):
@@ -101,13 +123,15 @@ class PyObjects:
 
     def find(self, object_str: str):
         """Finds any or all `PyObject` inside of `PyObjects` that match the `object_str`.
+
         It is case insensitive.
 
         Args:
             object_str (str): str to lookup in `PyObjects`
 
         Returns:
-            PyObjects: Returns a `PyObjects` class with all `PyObject` where the `PyObject.Name` matches `object_str`.
+            PyObjects: Returns a `PyObjects` class with all `PyObject`
+                where the `PyObject.Name` matches `object_str`.
         """
         items = [
             object

--- a/pytabular/partition.py
+++ b/pytabular/partition.py
@@ -1,5 +1,5 @@
-"""
-`partition.py` houses the main `PyPartition` and `PyPartitions` class.
+"""`partition.py` houses the main `PyPartition` and `PyPartitions` class.
+
 Once connected to your model, interacting with partition(s) will be done through these classes.
 """
 import logging
@@ -13,14 +13,20 @@ logger = logging.getLogger("PyTabular")
 
 
 class PyPartition(PyObject):
-    """Wrapper for [Partition](https://learn.microsoft.com/en-us/dotnet/api/microsoft.analysisservices.tabular.partition?view=analysisservices-dotnet).
-    With a few other bells and whistles added to it.
+    """Main class for interacting with partitions.
 
-    Args:
-        Table: Parent Table to the Column
+    See methods for available uses.
     """
 
     def __init__(self, object, table) -> None:
+        """Extends from `PyObject` class.
+
+        Adds a few custom rows to `rich` table for the partition.
+
+        Args:
+            object (Partition): .Net Partition object.
+            table (PyTable): Parent table of the partition in question.
+        """
         super().__init__(object)
         self.Table = table
         self._display.add_row("Mode", str(self._object.Mode))
@@ -33,7 +39,9 @@ class PyPartition(PyObject):
         )
 
     def last_refresh(self) -> datetime:
-        """Queries `RefreshedTime` attribute in the partition and converts from C# Ticks to Python datetime
+        """Queries `RefreshedTime` attribute in the partition.
+
+        Converts from C# Ticks to Python datetime.
 
         Returns:
             datetime.datetime: Last Refreshed time of Partition in datetime format
@@ -41,8 +49,11 @@ class PyPartition(PyObject):
         return ticks_to_datetime(self.RefreshedTime.Ticks)
 
     def refresh(self, *args, **kwargs) -> pd.DataFrame:
-        """Same method from Model Refresh, you can pass through any extra parameters. For example:
+        """Same method from Model Refresh.
+
+        You can pass through any extra parameters. For example:
         `Tabular().Tables['Table Name'].Partitions[0].refresh()`
+
         Returns:
             pd.DataFrame: Returns pandas dataframe with some refresh details
         """
@@ -50,13 +61,16 @@ class PyPartition(PyObject):
 
 
 class PyPartitions(PyObjects):
-    """
-    Groups together multiple partitions. See `PyObjects` class for what more it can do.
-    You can interact with `PyPartitions` straight from model. For ex: `model.Partitions`.
+    """Groups together multiple partitions.
+
+    See `PyObjects` class for what more it can do.
+    You can interact with `PyPartitions` straight from model.
+    For ex: `model.Partitions`.
     Or through individual tables `model.Tables[TABLE_NAME].Partitions`.
-    You can even filter down with `.Find()`. For example find all partition with `prev-year` in name.
-    `model.Partitions.Find('prev-year')`.
+    You can even filter down with `.find()`. For example find partitions with `prev-year` in name.
+    `model.Partitions.find('prev-year')`.
     """
 
     def __init__(self, objects) -> None:
+        """Extends through to `PyObjects`."""
         super().__init__(objects)

--- a/pytabular/pbi_helper.py
+++ b/pytabular/pbi_helper.py
@@ -1,4 +1,5 @@
-"""`pbi_helper.py` was reverse engineered from [DaxStudio PowerBiHelper.cs](https://github.com/DaxStudio/DaxStudio/blob/master/src/DaxStudio.UI/Utils/PowerBIHelper.cs).
+"""`pbi_helper.py` was reverse engineered from DaxStudio `PowerBiHelper.cs`.
+
 So all credit and genius should go to DaxStudio.
 I just wanted it in python...
 The main function is `find_local_pbi_instances()`.
@@ -9,10 +10,13 @@ import subprocess
 
 
 def get_msmdsrv() -> list:
-    """Runs powershel command to retrieve the ProcessId from Get-CimInstance where Name == 'msmdsrv.exe'.
+    """Runs powershel command to retrieve the ProcessId.
+
+    Uses `Get-CimInstance` where `Name == 'msmdsrv.exe'`.
 
     Returns:
-        list: returns ProcessId(s) in list format to account for multiple PBIX files open at the same time.
+        list: returns ProcessId(s) in list.
+            Formatted to account for multiple PBIX files open at the same time.
     """
     p.logger.debug("Retrieving msmdsrv.exe(s)")
 
@@ -20,7 +24,9 @@ def get_msmdsrv() -> list:
         msmdsrv = subprocess.check_output(
             [
                 "powershell",
-                """Get-CimInstance -ClassName Win32_Process -Property * -Filter "Name = 'msmdsrv.exe'" | Select-Object -Property ProcessId -ExpandProperty ProcessId""",
+                """Get-CimInstance -ClassName Win32_Process \
+                    -Property * -Filter "Name = 'msmdsrv.exe'" | \
+                    Select-Object -Property ProcessId -ExpandProperty ProcessId""",
             ]
         )
 
@@ -52,7 +58,9 @@ def get_port_number(msmdsrv: str) -> str:
     port = subprocess.check_output(
         [
             "powershell",
-            f"""Get-NetTCPConnection -State Listen -OwningProcess {msmdsrv} | Select-Object -Property LocalPort -First 1 -ExpandProperty LocalPort""",
+            f"Get-NetTCPConnection -State Listen \
+                -OwningProcess {msmdsrv} | Select-Object \
+                -Property LocalPort -First 1 -ExpandProperty LocalPort",
         ]
     )
     port_number = port.decode().strip()
@@ -72,7 +80,9 @@ def get_parent_id(msmdsrv: str) -> str:
     parent = subprocess.check_output(
         [
             "powershell",
-            f"""Get-CimInstance -ClassName Win32_Process -Property * -Filter "ProcessId = {msmdsrv}" | Select-Object -Property ParentProcessId -ExpandProperty ParentProcessId""",
+            f'Get-CimInstance -ClassName Win32_Process -Property * \
+                -Filter "ProcessId = {msmdsrv}" | \
+                Select-Object -Property ParentProcessId -ExpandProperty ParentProcessId',
         ]
     )
     parent_id = parent.decode().strip()
@@ -108,13 +118,15 @@ def get_parent_title(parent_id: str) -> str:
 
 
 def create_connection_str(port_number: str) -> str:
-    """This takes the port number and adds to connection string. This is pretty bland right now, may improve later.
+    """This takes the port number and adds to connection string.
+
+    This is pretty bland right now, may improve later.
 
     Args:
-        port_number (str): Port Number retrieved from `get_port_number(msmdsrv)`.
+        port_number (str): port number retrieved from `get_port_number(msmdsrv)`.
 
     Returns:
-        str: _description_
+        str: port number as string.
     """
     connection_str = f"Data Source=localhost:{port_number}"
     p.logger.debug(f"Local Connection Str - {connection_str}")
@@ -122,15 +134,17 @@ def create_connection_str(port_number: str) -> str:
 
 
 def find_local_pbi_instances() -> list:
-    """The real genius is from this [Dax Studio PowerBIHelper](https://github.com/DaxStudio/DaxStudio/blob/master/src/DaxStudio.UI/Utils/PowerBIHelper.cs).
+    """The real genius is from Dax Studio.
+
     I just wanted it in python not C#, so reverse engineered what DaxStudio did.
     It will run some powershell scripts to pull the appropriate info.
     Then will spit out a list with tuples inside.
     You can use the connection string to connect to your model with pytabular.
+    [Dax Studio](https://github.com/DaxStudio/DaxStudio/blob/master/src/DaxStudio.UI/Utils/PowerBIHelper.cs).
 
     Returns:
-        list: Example -  `[('PBI File Name1','localhost:{port}'),('PBI File Name2','localhost:{port}')]`
-    """
+        list: EX `[('PBI File Name1','localhost:{port}'),('PBI File Name2','localhost:{port}')]`
+    """  # noqa: E501
     instances = get_msmdsrv()
     pbi_instances = []
     for instance in instances:

--- a/pytabular/pytabular.py
+++ b/pytabular/pytabular.py
@@ -1,5 +1,5 @@
-"""
-`pytabular.py` is where it all started. So there is a lot of old methods that will eventually be deprecated.
+"""`pytabular.py` is where it all started.
+
 Main class is `Tabular()`. Use that for connecting with your models.
 """
 import logging
@@ -40,23 +40,27 @@ logger = logging.getLogger("PyTabular")
 
 
 class Tabular(PyObject):
-    """Tabular Class to perform operations: [Microsoft.AnalysisServices.Tabular](https://docs.microsoft.com/en-us/dotnet/api/microsoft.analysisservices.tabular?view=analysisservices-dotnet). You can use this class as your main way to interact with your model.
+    """Tabular Class to perform operations.
+
+    This is the main class to work with in PyTabular.
+    You can connect to the other classes via the supplied attributes.
 
     Args:
-            connection_str (str): Valid [Connection String](https://docs.microsoft.com/en-us/analysis-services/instances/connection-string-properties-analysis-services?view=asallproducts-allversions) for connecting to a Tabular Model.
+            connection_str (str): Need a valid connection string:
+                [link](https://learn.microsoft.com/en-us/analysis-services/instances/connection-string-properties-analysis-services)
+
     Attributes:
-            Server (Server): See [Server MS Docs](https://docs.microsoft.com/en-us/dotnet/api/microsoft.analysisservices.server?view=analysisservices-dotnet).
-            Catalog (str): Name of Database. See [Catalog MS Docs](https://learn.microsoft.com/en-us/dotnet/api/microsoft.analysisservices.connectioninfo.catalog?view=analysisservices-dotnet#microsoft-analysisservices-connectioninfo-catalog).
-            Model (Model): See [Model MS Docs](https://learn.microsoft.com/en-us/dotnet/api/microsoft.analysisservices.tabular.model?view=analysisservices-dotnet).
-            AdomdConnection (AdomdConnection): For querying. See [AdomdConnection MS Docs](https://learn.microsoft.com/en-us/dotnet/api/microsoft.analysisservices.adomdclient.adomdconnection?view=analysisservices-dotnet). Connection made from parts of the originally provided connection string.
-            Tables (PyTables[PyTable]): Wrappers for [Table MS Docs](https://learn.microsoft.com/en-us/dotnet/api/microsoft.analysisservices.tabular.table?view=analysisservices-dotnet). So you have the full capabilities of what the MS Docs offer and a few others. Like `Tabular().Tables['Table Name'].Row_Count()`. Or you can find a table via `Tabular().Tables[0]` or `Tabular().Tables['Table Name']`
-            Columns (List[Column]): Easy access list of columns from model. See [Column MS Docs](https://learn.microsoft.com/en-us/dotnet/api/microsoft.analysisservices.tabular.column?view=analysisservices-dotnet).
-            Partitions (List[Partition]): Easy access list of partitions from model. See [Partition MS Docs](https://learn.microsoft.com/en-us/dotnet/api/microsoft.analysisservices.partition?view=analysisservices-dotnet).
-            Measures (List[Measure]): Easy access list of measures from model. See [Measure MS Docs](https://learn.microsoft.com/en-us/dotnet/api/microsoft.analysisservices.tabular.table.measures?view=analysisservices-dotnet#microsoft-analysisservices-tabular-table-measures).
+            AdomdConnection (Connection): For querying.
+                This is the `Connection` class.
+            Tables (PyTables[PyTable]): See `PyTables` for more information.
+                Iterate through your tables in your model.
+            Columns (PyColumns[PyColumn]): See `PyColumns` for more information.
+            Partitions (PyPartitions[PyPartition]): See `PyPartitions` for more information.
+            Measures (PyMeasures[PyMeasure]): See `PyMeasures` for more information.
     """
 
     def __init__(self, connection_str: str):
-
+        """Connect to model. Just supply a solid connection string."""
         # Connecting to model...
         logger.debug("Initializing Tabular Class")
         self.Server = Server()
@@ -110,7 +114,10 @@ class Tabular(PyObject):
         atexit.register(self.disconnect)
 
     def reload_model_info(self) -> bool:
-        """Runs on __init__ iterates through details, can be called after any model changes. Called in save_changes()
+        """Reload your model info into the `Tabular` class.
+
+        Should be called after any model changes.
+        Called in `save_changes()` and `__init__()`.
 
         Returns:
                 bool: True if successful
@@ -145,7 +152,10 @@ class Tabular(PyObject):
         return True
 
     def is_process(self) -> bool:
-        """Run method to check if Processing is occurring. Will query DMV $SYSTEM.DISCOVER_JOBS to see if any processing is happening.
+        """Run method to check if Processing is occurring.
+
+        Will query DMV `$SYSTEM.DISCOVER_JOBS`
+        to see if any processing is happening.
 
         Returns:
                 bool: True if DMV shows Process, False if not.
@@ -154,43 +164,34 @@ class Tabular(PyObject):
         return len(_jobs_df[_jobs_df["JOB_DESCRIPTION"] == "Process"]) > 0
 
     def disconnect(self) -> None:
-        """Disconnects from Model"""
+        """Disconnects from Model."""
         logger.info(f"Disconnecting from - {self.Server.Name}")
         atexit.unregister(self.disconnect)
         return self.Server.Disconnect()
 
     def reconnect(self) -> None:
-        """Reconnects to Model"""
+        """Reconnects to Model."""
         logger.info(f"Reconnecting to {self.Server.Name}")
         return self.Server.Reconnect()
 
     def refresh(self, *args, **kwargs) -> pd.DataFrame:
-        """PyRefresh Class to handle refreshes of model.
+        """`PyRefresh` class to handle refreshes of model.
 
-        Args:
-            model (Tabular): Main Tabular Class
-            object (Union[str, PyTable, PyPartition, Dict[str, Any]]): Designed to handle a few different ways of selecting a refresh. Can be a string of 'Table Name' or dict of {'Table Name': 'Partition Name'} or even some combination with the actual PyTable and PyPartition classes.
-            trace (Base_Trace, optional): Set to `None` if no Tracing is desired, otherwise you can use default trace or create your own. Defaults to Refresh_Trace.
-            refresh_checks (Refresh_Check_Collection, optional): Add your `Refresh_Check`'s into a `Refresh_Check_Collection`. Defaults to Refresh_Check_Collection().
-            default_row_count_check (bool, optional): Quick built in check will fail the refresh if post check row count is zero. Defaults to True.
-            refresh_type (RefreshType, optional): Input RefreshType desired. Defaults to RefreshType.Full.
-
-        Returns:
-            pd.DataFrame
+        See the `PyRefresh()` class for more details on what you can do with this.
         """
         return self.PyRefresh(self, *args, **kwargs).run()
 
     def save_changes(self):
         """Called after refreshes or any model changes.
-        Currently will return a named tuple of all changes detected. However a ton of room for improvement here.
+
+        Currently will return a named tuple of all changes detected.
+        A ton of room for improvement on what gets returned here.
         """
         if self.Server.Connected is False:
             self.reconnect()
 
         def property_changes(property_changes_var):
-            """
-            Returns any property changes.
-            """
+            """Returns any property changes."""
             property_change = namedtuple(
                 "property_change",
                 "new_value object original_value property_name property_type",
@@ -220,7 +221,8 @@ class Tabular(PyObject):
             xmla_results = model_save_results.XmlaResults
             changes = namedtuple(
                 "changes",
-                "property_changes added_objects added_subtree_roots removed_objects removed_subtree_Roots xmla_results",
+                "property_changes added_objects added_subtree_roots \
+                    removed_objects removed_subtree_Roots xmla_results",
             )
             [
                 property_changes(property_changes_var),
@@ -241,16 +243,9 @@ class Tabular(PyObject):
             )
 
     def backup_table(self, table_str: str) -> bool:
-        """Will be removed. This is experimental with no written pytest for it.
-        Backs up table in memory, brings with it measures, columns, hierarchies, relationships, roles, etc.
-        It will add suffix '_backup' to all objects.
-        Refresh is performed from source during backup.
+        """Will be removed.
 
-        Args:
-                table_str (str, optional): Name of Table.
-
-        Returns:
-                bool: Returns True if Successful, else will return error.
+        Used in conjunction with `revert_table()`.
         """
         logger.info("Backup Beginning...")
         logger.debug(f"Cloning {table_str}")
@@ -343,19 +338,9 @@ class Tabular(PyObject):
         return True
 
     def revert_table(self, table_str: str) -> bool:
-        """Will be removed. This is experimental with no written pytest for it. This is used in conjunction with Backup_Table().
-        It will take the 'TableName_backup' and replace with the original.
-        Example scenario ->
-        1. model.Backup_Table('TableName')
-        2. perform any proposed changes in original 'TableName'
-        3. validate changes in 'TableName'
-        4. if unsuccessful run model.Revert_Table('TableName')
+        """Will be removed.
 
-        Args:
-                table_str (str): Name of table.
-
-        Returns:
-                bool: Returns True if Successful, else will return error.
+        This is used in conjunction with `backup_table()`.
         """
         logger.info(f"Beginning Revert for {table_str}")
         logger.debug(f"Finding original {table_str}")
@@ -378,9 +363,7 @@ class Tabular(PyObject):
         ]
 
         def remove_role_permissions():
-            """
-            Removes role permissions from table.
-            """
+            """Removes role permissions from table."""
             logger.debug(
                 f"Finding table and column permission in roles to remove from {table_str}"
             )
@@ -414,9 +397,7 @@ class Tabular(PyObject):
         remove_role_permissions()
 
         def dename(items):
-            """
-            Denames all items.
-            """
+            """Denames all items."""
             for item in items:
                 logger.debug(f"Removing Suffix for {item.Name}")
                 item.RequestRename(remove_suffix(item.Name, "_backup"))
@@ -447,16 +428,19 @@ class Tabular(PyObject):
     def query(
         self, query_str: str, effective_user: str = None
     ) -> Union[pd.DataFrame, str, int]:
-        """Executes Query on Model and Returns Results in Pandas DataFrame
+        """Executes query on model.
+
+        See `Connection().query()` for details on execution.
 
         Args:
-                query_Str (str): Dax Query. Note, needs full syntax (ex: EVALUATE). See (DAX Queries)[https://docs.microsoft.com/en-us/dax/dax-queries].
-                Will check if query string is a file. If it is, then it will perform a query on whatever is read from the file.
-                It is also possible to query DMV. For example. Query("select * from $SYSTEM.DISCOVER_TRACE_EVENT_CATEGORIES"). See (DMVs)[https://docs.microsoft.com/en-us/analysis-services/instances/use-dynamic-management-views-dmvs-to-monitor-analysis-services?view=asallproducts-allversions]
-                effective_user (str): User you wish to query as.
+            query_str (str): Query string to execute.
+            effective_user (str, optional): Pass through an effective user
+            if desired. It will create and store a new `Connection()` class if need,
+            which will help with speed if looping through multiple users in a row.
+            Defaults to None.
 
         Returns:
-                pd.DataFrame: Returns dataframe with results
+            Union[pd.DataFrame, str, int]: _description_
         """
         if effective_user is None:
             return self.Adomd.query(query_str)
@@ -476,20 +460,27 @@ class Tabular(PyObject):
         self, tabular_editor_exe: str, best_practice_analyzer: str
     ) -> List[str]:
         """Takes your Tabular Model and performs TE2s BPA. Runs through Command line.
-        [Tabular Editor BPA](https://docs.tabulareditor.com/te2/Best-Practice-Analyzer.html)
-        [Tabular Editor Command Line Options](https://docs.tabulareditor.com/te2/Command-line-Options.html)
+
+        Nothing fancy hear. Really just a simple wrapper so you could
+        call BPA in the same python script.
 
         Args:
-                tabular_editor_exe (str): TE2 Exe File path. Feel free to use class TE2().EXE_Path or provide your own.
-                best_practice_analyzer (str): BPA json file path. Feel free to use class BPA().Location or provide your own. Defualts to 	https://raw.githubusercontent.com/microsoft/Analysis-Services/master/BestPracticeRules/BPARules.json
+                tabular_editor_exe (str): TE2 Exe File path.
+                    Feel free to use class TE2().EXE_Path or provide your own.
+                best_practice_analyzer (str): BPA json file path.
+                    Feel free to use class BPA().Location or provide your own.
 
         Returns:
-                List[str]: Assuming no failure, will return list of BPA violations. Else will return error from command line.
+                List[str]: Assuming no failure,
+                    will return list of BPA violations.
+                    Else will return error from command line.
         """
         logger.debug("Beginning request to talk with TE2 & Find BPA...")
         bim_file_location = f"{os.getcwd()}\\Model.bim"
         atexit.register(remove_file, bim_file_location)
-        cmd = f'{tabular_editor_exe} "Provider=MSOLAP;{self.Adomd.ConnectionString}" {self.Database.Name} -B "{bim_file_location}" -A {best_practice_analyzer} -V/?'
+        cmd = f'{tabular_editor_exe} "Provider=MSOLAP;\
+            {self.Adomd.ConnectionString}" {self.Database.Name} -B "{bim_file_location}" \
+            -A {best_practice_analyzer} -V/?'
         logger.debug("Command Generated")
         logger.debug("Submitting Command...")
         sp = subprocess.Popen(
@@ -508,13 +499,17 @@ class Tabular(PyObject):
             ]
 
     def create_table(self, df: pd.DataFrame, table_name: str) -> bool:
-        """Creates tables from pd.DataFrame as an M-Partition.
-        So will convert the dataframe to M-Partition logic via the M query table constructor.
-        Runs refresh and will update model.
+        """Creates table from pd.DataFrame to a table in your model.
+
+        It will convert the dataframe to M-Partition logic via the M query table constructor.
+        Then will run a refresh and update model.
+        Has some obvious limitations right now, because
+        the datframe values are hard coded into M-Partition,
+        which means you could hit limits with the size of your table.
 
         Args:
-                df (pd.DataFrame): DataFrame to add to model
-                table_name (str): _description_
+                df (pd.DataFrame): DataFrame to add to model.
+                table_name (str): Name of the table.
 
         Returns:
                 bool: True if successful
@@ -539,11 +534,13 @@ class Tabular(PyObject):
         logger.debug("Setting MPartition Expression...")
         partition.Source.set_Expression(pd_dataframe_to_m_expression(df))
         logger.debug(
-            f"Adding partition: {partition.Name} to {self.Server.Name}::{self.Database.Name}::{self.Model.Name}"
+            f"Adding partition: {partition.Name} to {self.Server.Name}\
+                ::{self.Database.Name}::{self.Model.Name}"
         )
         new_table.Partitions.Add(partition)
         logger.debug(
-            f"Adding table: {new_table.Name} to {self.Server.Name}::{self.Database.Name}::{self.Model.Name}"
+            f"Adding table: {new_table.Name} to {self.Server.Name}\
+                ::{self.Database.Name}::{self.Model.Name}"
         )
         self.Model.Tables.Add(new_table)
         self.save_changes()

--- a/pytabular/query.py
+++ b/pytabular/query.py
@@ -1,5 +1,5 @@
-"""
-`query.py` houses a custom `Connection` class that uses the .Net AdomdConnection.
+"""`query.py` houses a custom `Connection` class that uses the .Net AdomdConnection.
+
 `Connection` is created automatically when connecting to your model.
 """
 import logging
@@ -14,14 +14,22 @@ logger = logging.getLogger("PyTabular")
 
 
 class Connection(AdomdConnection):
-    """Subclass for [Adomdclient](https://learn.microsoft.com/en-us/dotnet/api/microsoft.analysisservices.adomdclient?view=analysisservices-dotnet). With some extra items on top.
-    Right now designed for internal use. For example, Query method in the Tabular class is just a wrapper for this class' Query method... So use that instead.
+    """Connection class creates an AdomdConnection.
 
-    Args:
-        AdomdConnection (_type_): _description_
+    Mainly used for the `query()` method. The `query()`
+    method in the Tabular class is just a wrapper for this class.
+    But you can pass through your `effective_user` more efficiently,
+    so use that instead.
     """
 
     def __init__(self, server, effective_user=None) -> None:
+        """Init creates the connection.
+
+        Args:
+            server (Server): The server that you are connecting to.
+            effective_user (str, optional): Pass through an effective user
+                to query as somebody else. Defaults to None.
+        """
         super().__init__()
         if server.ConnectionInfo.Password is None:
             connection_string = server.ConnectionString
@@ -35,15 +43,24 @@ class Connection(AdomdConnection):
         self.ConnectionString = connection_string
 
     def query(self, query_str: str) -> Union[pd.DataFrame, str, int]:
-        """Executes Query on Model and Returns results in Pandas DataFrame
+        """Executes query on Model and returns results in Pandas DataFrame.
+
+        Iterates through results of `AdomdCommmand().ExecuteReader()`
+        in the .Net library. If result is a single value, it will
+        return that single value instead of DataFrame.
 
         Args:
-                query_str (str): Dax Query. Note, needs full syntax (ex: EVALUATE). See (DAX Queries)[https://docs.microsoft.com/en-us/dax/dax-queries].
-                Will check if query string is a file. If it is, then it will perform a query on whatever is read from the file.
-                It is also possible to query DMV. For example. Query("select * from $SYSTEM.DISCOVER_TRACE_EVENT_CATEGORIES"). See (DMVs)[https://docs.microsoft.com/en-us/analysis-services/instances/use-dynamic-management-views-dmvs-to-monitor-analysis-services?view=asallproducts-allversions]
+            query_str (str): Dax Query. Note, needs full syntax
+                (ex: `EVALUATE`). See (DAX)[https://docs.microsoft.com/en-us/dax/dax-queries].
+                Will check if query string is a file.
+                If it is, then it will perform a query
+                on whatever is read from the file.
+                It is also possible to query DMV.
+                For example.
+                `query("select * from $SYSTEM.DISCOVER_TRACE_EVENT_CATEGORIES")`.
 
         Returns:
-                pd.DataFrame: Returns dataframe with results
+            pd.DataFrame: Returns dataframe with results.
         """
         try:
             is_file = os.path.isfile(query_str)

--- a/pytabular/relationship.py
+++ b/pytabular/relationship.py
@@ -1,6 +1,7 @@
-"""
-`relationship.py` houses the main `PyRelationship` and `PyRelationships` class.
-Once connected to your model, interacting with relationship(s) will be done through these classes.
+"""`relationship.py` houses the main `PyRelationship` and `PyRelationships` class.
+
+Once connected to your model, interacting with relationship(s)
+will be done through these classes.
 """
 import logging
 from object import PyObject, PyObjects
@@ -17,9 +18,19 @@ logger = logging.getLogger("PyTabular")
 
 
 class PyRelationship(PyObject):
-    """Wrapper for [Relationship Class](https://learn.microsoft.com/en-us/dotnet/api/microsoft.analysisservices.relationship?view=analysisservices-dotnet)."""
+    """The main class for interacting with relationships in your model."""
 
     def __init__(self, object, model) -> None:
+        """Init extends to `PyObject`.
+
+        It also extends a few unique rows to `rich` table.
+        A few easy access attributes have been added.
+        For example, see `self.From_Table` or `self.To_Column`
+
+        Args:
+            object (_type_): _description_
+            model (_type_): _description_
+        """
         super().__init__(object)
         self.Model = model
         self.CrossFilteringBehavior = CrossFilteringBehavior(
@@ -44,12 +55,15 @@ class PyRelationship(PyObject):
 
 
 class PyRelationships(PyObjects):
-    """
-    Groups together multiple relationships. See `PyObjects` class for what more it can do.
-    You can interact with `PyRelationships` straight from model. For ex: `model.Relationships`.
+    """Groups together multiple relationships.
+
+    See `PyObjects` class for what more it can do.
+    You can interact with `PyRelationships` straight from model.
+    For ex: `model.Relationships`.
     """
 
     def __init__(self, objects) -> None:
+        """Init just extends from PyObjects."""
         super().__init__(objects)
 
     def related(self, object: Union[PyTable, str]) -> PyTables:

--- a/pytabular/tabular_editor.py
+++ b/pytabular/tabular_editor.py
@@ -1,5 +1,5 @@
-"""
-This has a `Tabular_Editor` class which will download TE2 from a default location.
+"""This has a `Tabular_Editor` class which will download TE2 from a default location.
+
 Or you can input your own location.
 """
 import logging
@@ -13,16 +13,24 @@ logger = logging.getLogger("PyTabular")
 
 
 def download_tabular_editor(
-    download_location: str = "https://github.com/TabularEditor/TabularEditor/releases/download/2.16.7/TabularEditor.Portable.zip",
+    download_location: str = (
+        "https://github.com/TabularEditor/TabularEditor/releases/download/2.16.7/TabularEditor.Portable.zip"  # noqa: E501
+    ),
     folder: str = "Tabular_Editor_2",
     auto_remove=True,
 ) -> str:
-    """Runs a request.get() to retrieve the zip file from web. Will unzip response and store in directory. Will also register the removal of the new directory and files when exiting program.
+    """Runs a request.get() to retrieve the zip file from web.
+
+    Will unzip response and store in directory.
+    Will also register the removal of the new directory
+    and files when exiting program.
 
     Args:
-            download_location (str, optional): File path for zip of Tabular Editor 2. Defaults to [Tabular Editor 2 Github Zip Location]'https://github.com/TabularEditor/TabularEditor/releases/download/2.16.7/TabularEditor.Portable.zip'.
-            folder (str, optional): New Folder Location. Defaults to 'Tabular_Editor_2'.
-            auto_remove (bool, optional): Boolean to determine auto removal of files once script exits. Defaults to True.
+            download_location (str, optional): File path for zip of Tabular Editor 2.
+                See code args for default download url.
+            folder (str, optional): New Folder Location. Defaults to "Tabular_Editor_2".
+            auto_remove (bool, optional): Boolean to determine auto
+                removal of files once script exits. Defaults to True.
 
     Returns:
             str: File path of TabularEditor.exe
@@ -47,10 +55,21 @@ def download_tabular_editor(
 
 class TabularEditor:
     """Setting Tabular_Editor Class for future work.
+
     Mainly runs `download_tabular_editor()`
     """
 
     def __init__(self, exe_file_path: str = "Default") -> None:
+        """Init for `TabularEditor()` class.
+
+        This is mostly a placeholder right now.
+        But useful if you want an easy way to download TE2.
+
+        Args:
+            exe_file_path (str, optional): File path where TE2 lives. Defaults to "Default".
+                If "Default", it will run `download_tabular_editor()`
+                and download from github.
+        """
         logger.debug(f"Initializing Tabular Editor Class:: {exe_file_path}")
         if exe_file_path == "Default":
             self.exe: str = download_tabular_editor()

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,1 @@
+"""Init for pytest."""

--- a/test/config.py
+++ b/test/config.py
@@ -1,3 +1,4 @@
+"""Custom configurations for pytest."""
 import pytabular as p
 import os
 import pandas as pd
@@ -7,6 +8,7 @@ from time import sleep
 
 
 def get_test_path():
+    """Gets working test path."""
     cwd = os.getcwd()
     if os.path.basename(cwd) == "test":
         return cwd
@@ -20,6 +22,7 @@ adventureworks_path = f'"{get_test_path()}\\adventureworks\\AdventureWorks Sales
 
 
 def find_local_pbi():
+    """Finds local pbix file if exists. Otherwise, will open AdventureWorks."""
     attempt = p.find_local_pbi_instances()
     if len(attempt) > 0:
         return attempt[0]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,9 @@
+"""pytest conftest.py.
+
+Has a `TestingStorage()` class to pass parameters from one test to another.
+This file also has functions that give instructions on start and finish of pytest.
+See `config.py` for more testing configurations.
+"""
 from test.config import (
     local_pbix,
     testingtablename,
@@ -7,15 +13,19 @@ import pytabular as p
 
 
 class TestStorage:
+    """Class to pass parameters from on pytest to another."""
+
     query_trace = None
     documentation_class = None
 
 
 def pytest_report_header(config):
+    """Pytest header name."""
     return "PyTabular Local Testing"
 
 
 def remove_testing_table(model):
+    """Function to remove the testing table."""
     table_check = [
         table
         for table in model.Model.Tables.GetEnumerator()
@@ -28,6 +38,10 @@ def remove_testing_table(model):
 
 
 def pytest_sessionstart(session):
+    """Run at pytest start.
+
+    Removes testing table if exists, and creates a new one.
+    """
     p.logger.info("Executing pytest setup...")
     remove_testing_table(local_pbix)
     local_pbix.create_table(testingtabledf, testingtablename)
@@ -35,6 +49,7 @@ def pytest_sessionstart(session):
 
 
 def pytest_sessionfinish(session, exitstatus):
+    """On pytest finish it will remove testing table."""
     p.logger.info("Executing pytest cleanup...")
     remove_testing_table(local_pbix)
     # p.logger.info("Finding and closing PBIX file...")

--- a/test/test_10logic_utils.py
+++ b/test/test_10logic_utils.py
@@ -1,5 +1,4 @@
-"""pytest for the table.py file. Covers the PyTable and PyTables classes.
-"""
+"""pytest for the table.py file. Covers the PyTable and PyTables classes."""
 from test.config import testing_parameters
 import pytest
 from pytabular import logic_utils
@@ -34,6 +33,10 @@ suffix_list = [
     ],
 )
 def test_remove_suffix(file_name, suffix):
+    """Tests `remove_suffix()` function.
+
+    Note this exists so lower python versions can stay compatible.
+    """
     result = logic_utils.remove_suffix(file_name, suffix)
     assert suffix not in result
 
@@ -46,11 +49,13 @@ dfs = [
 
 @pytest.mark.parametrize("df", dfs)
 def test_dataframe_to_dict(df):
+    """Tests `dataframe_to_dict()` function."""
     assert isinstance(logic_utils.dataframe_to_dict(df), list)
 
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_dict_to_markdown_table(model):
+    """Tests `dict_to_markdown_table()` function."""
     dependencies = [measure.get_dependencies() for measure in model.Measures]
     columns = ["Referenced Object Type", "Referenced Table", "Referenced Object"]
     result = logic_utils.dict_to_markdown_table(dependencies, columns)
@@ -58,6 +63,7 @@ def test_dict_to_markdown_table(model):
 
 
 def test_remove_dir():
+    """Tests removing a directory."""
     dir = "testing_to_be_deleted"
     os.makedirs(dir)
     remove = f"{os.getcwd()}\\{dir}"
@@ -66,6 +72,7 @@ def test_remove_dir():
 
 
 def test_remove_file():
+    """Tests removing a file."""
     file_to_delete = "testing_to_be_deleted.txt"
     with open(file_to_delete, "w") as f:
         f.write("Delete this file...")

--- a/test/test_11document.py
+++ b/test/test_11document.py
@@ -1,5 +1,4 @@
-"""Tests to cover the document.py file
-"""
+"""Tests to cover the document.py file."""
 from test.config import testing_parameters
 import pytest
 import pytabular as p
@@ -10,6 +9,7 @@ from test.conftest import TestStorage
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_basic_document_funcionality(model):
+    """Tests basic documentation functionality."""
     try:
         docs = p.ModelDocumenter(model=model)
         docs.generate_documentation_pages()
@@ -20,6 +20,7 @@ def test_basic_document_funcionality(model):
 
 
 def test_basic_documentation_removed():
+    """Tests that created documentation gets removed."""
     docs_class = TestStorage.documentation_class
     remove = f"{docs_class.save_location}/{docs_class.friendly_name}"
     logic_utils.remove_folder_and_contents(remove)

--- a/test/test_1sanity.py
+++ b/test/test_1sanity.py
@@ -1,3 +1,8 @@
+"""Sanity pytests.
+
+Does 1 actually equal 1?
+Or am I crazy person about to descend into madness.
+"""
 import pytest
 from Microsoft.AnalysisServices.Tabular import Database
 from test.config import testing_parameters
@@ -5,19 +10,17 @@ from test.config import testing_parameters
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_sanity_check(model):
-    """Just in case... I might be crazy"""
+    """Just in case... I might be crazy."""
     assert 1 == 1
 
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_connection(model):
-    """
-    Does a quick check to the Tabular Class
-    To ensure that it can connnect
-    """
+    """Does a quick check on connection to `Tabular()` class."""
     assert model.Server.Connected
 
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_database(model):
+    """Tests that `model.Database` is actually a Database."""
     assert isinstance(model.Database, Database)

--- a/test/test_2object.py
+++ b/test/test_2object.py
@@ -1,5 +1,4 @@
-"""pytest for the table.py file. Covers the PyTable and PyTables classes.
-"""
+"""pytest for the table.py file. Covers the PyTable and PyTables classes."""
 from test.config import testing_parameters
 import pytest
 from pytabular import Tabular
@@ -7,6 +6,7 @@ from pytabular import Tabular
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_rich_repr_model(model):
+    """Tests successful `__rich_repr()` `on Tabular()` class."""
     try:
         model.__rich_repr__()
     except Exception:
@@ -15,6 +15,7 @@ def test_rich_repr_model(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_rich_repr_table(model):
+    """Tests successful `__rich_repr()` `on PyTable()` class."""
     try:
         model.Tables[0].__rich_repr__()
     except Exception:
@@ -23,6 +24,7 @@ def test_rich_repr_table(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_rich_repr_tables(model):
+    """Tests successful `__rich_repr()` `on PyTables()` class."""
     try:
         model.Tables.__rich_repr__()
     except Exception:
@@ -31,6 +33,7 @@ def test_rich_repr_tables(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_rich_repr_column(model):
+    """Tests successful `__rich_repr()` `on PyColumn()` class."""
     try:
         model.Columns[0].__rich_repr__()
     except Exception:
@@ -39,6 +42,7 @@ def test_rich_repr_column(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_rich_repr_columns(model):
+    """Tests successful `__rich_repr()` `on PyColumns()` class."""
     try:
         model.Columns.__rich_repr__()
     except Exception:
@@ -47,6 +51,7 @@ def test_rich_repr_columns(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_rich_repr_partition(model):
+    """Tests successful `__rich_repr()` `on PyPartition()` class."""
     try:
         model.Partitions[0].__rich_repr__()
     except Exception:
@@ -55,6 +60,7 @@ def test_rich_repr_partition(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_rich_repr_partitions(model):
+    """Tests successful `__rich_repr()` `on PyPartitions()` class."""
     try:
         model.Partitions.__rich_repr__()
     except Exception:
@@ -63,6 +69,7 @@ def test_rich_repr_partitions(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_rich_repr_measure(model):
+    """Tests successful `__rich_repr()` `on PyMeasure()` class."""
     try:
         model.Measures[0].__rich_repr__()
     except Exception:
@@ -71,20 +78,22 @@ def test_rich_repr_measure(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_rich_repr_measures(model):
+    """Tests successful `__rich_repr()` `on PyMeasures()` class."""
     try:
         model.Measures.__rich_repr__()
     except Exception:
         pytest.fail("__rich_repr__() failed")
 
 
-# TODO need to get this to have coverage for full getattr
 @pytest.mark.parametrize("model", testing_parameters)
 def test_get_attr(model):
+    """Tests custom get attribute from `PyObject` class."""
     assert isinstance(model.Tables[0].Model, Tabular)
 
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_iadd_tables(model):
+    """Tests `__iadd__()` with `PyTables()`."""
     a = model.Tables.find("Sales")
     b = model.Tables.find("Date")
     a += b
@@ -93,6 +102,7 @@ def test_iadd_tables(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_iadd_table(model):
+    """Tests `__iadd__()` with a `PyTable()`."""
     a = model.Tables.find("Sales")
     b = model.Tables.find("Date")[0]
     a += b

--- a/test/test_3tabular.py
+++ b/test/test_3tabular.py
@@ -1,3 +1,4 @@
+"""Bulk of pytests for `Tabular()` class."""
 import pytest
 import pandas as pd
 import pytabular as p
@@ -6,6 +7,7 @@ from test.config import testingtablename, testing_parameters, get_test_path
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_basic_query(model):
+    """Tests a basic query execution."""
     int_result = model.query("EVALUATE {1}")
     text_result = model.query('EVALUATE {"Hello World"}')
     assert int_result == 1 and text_result == "Hello World"
@@ -20,6 +22,7 @@ datatype_queries = [
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_datatype_query(model):
+    """Tests the results of different datatypes."""
     for query in datatype_queries:
         result = model.query(f"EVALUATE {{{query[1]}}}")
         assert result == query[0]
@@ -27,6 +30,7 @@ def test_datatype_query(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_file_query(model):
+    """Test `query()` via a file."""
     singlevaltest = get_test_path() + "\\singlevaltest.dax"
     dfvaltest = get_test_path() + "\\dfvaltest.dax"
     dfdupe = pd.DataFrame({"[Value1]": (1, 3), "[Value2]": (2, 4)})
@@ -35,26 +39,31 @@ def test_file_query(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_repr_str(model):
+    """Testing successful `__repr__()` on model."""
     assert isinstance(model.__repr__(), str)
 
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_pytables_count(model):
+    """Testing row count of testingtable."""
     assert model.Tables[testingtablename].row_count() > 0
 
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_pytables_refresh(model):
+    """Tests refrshing table of testingtable."""
     assert len(model.Tables[testingtablename].refresh()) > 0
 
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_pypartitions_refresh(model):
+    """Tests refreshing partition of testingtable."""
     assert len(model.Tables[testingtablename].Partitions[0].refresh()) > 0
 
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_pyobjects_adding(model):
+    """Tests adding a PyObject."""
     table = model.Tables.find(testingtablename)
     table += table
     assert len(table) == 2
@@ -62,10 +71,13 @@ def test_pyobjects_adding(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_nonetype_decimal_bug(model):
+    """Tests the pesky nonetype decimal bug."""
     query_str = """
     EVALUATE
     {
-        (1, CONVERT( 1.24, CURRENCY ), "Hello"), (2, CONVERT( 87661, CURRENCY ), "World"), (3,,"Test")
+        (1, CONVERT( 1.24, CURRENCY ), "Hello"),
+        (2, CONVERT( 87661, CURRENCY ), "World"),
+        (3,,"Test")
     }
     """
     assert len(model.query(query_str)) == 3
@@ -73,18 +85,19 @@ def test_nonetype_decimal_bug(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_table_last_refresh_times(model):
-    """Really just testing the the function completes successfully and returns df"""
+    """Really just testing the the function completes successfully and returns df."""
     assert isinstance(model.Tables.last_refresh(), pd.DataFrame)
 
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_return_zero_row_tables(model):
-    """Testing that `Return_Zero_Row_Tables`"""
+    """Testing that `find_zero_rows()`."""
     assert isinstance(model.Tables.find_zero_rows(), p.pytabular.PyTables)
 
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_get_dependencies(model):
+    """Tests execution of `PyMeasure.get_dependencies()`."""
     dependencies = model.Measures[0].get_dependencies()
     assert len(dependencies) > 0
 
@@ -105,7 +118,7 @@ def test_reconnect(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_reconnect_savechanges(model):
-    """This will test the `reconnect()` gets called in `save_changes()`"""
+    """This will test the `reconnect()` gets called in `save_changes()`."""
     model.disconnect()
     model.save_changes()
     assert model.Server.Connected is True
@@ -113,20 +126,20 @@ def test_reconnect_savechanges(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_is_process(model):
-    """Checks that `Is_Process()` from `Tabular` class returns bool"""
+    """Checks that `Is_Process()` from `Tabular` class returns bool."""
     assert isinstance(model.is_process(), bool)
 
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_bad_table(model):
-    """Checks for unable to find table exception"""
+    """Checks for unable to find table exception."""
     with pytest.raises(Exception):
         model.refresh("badtablename")
 
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_refresh_dict(model):
-    """Checks for refreshing dictionary"""
+    """Checks for refreshing dictionary."""
     table = model.Tables[testingtablename]
     refresh = model.refresh({table.Name: table.Partitions[0].Name})
     assert isinstance(refresh, pd.DataFrame)
@@ -134,7 +147,7 @@ def test_refresh_dict(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_refresh_dict_pypartition(model):
-    """Checks for refreshing dictionary"""
+    """Checks for refreshing dictionary with PyPartition."""
     table = model.Tables[testingtablename]
     refresh = model.refresh({table.Name: table.Partitions[0]})
     assert isinstance(refresh, pd.DataFrame)
@@ -142,7 +155,7 @@ def test_refresh_dict_pypartition(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_bad_partition(model):
-    """Checks for refreshing dictionary"""
+    """Checks for refreshing dictionary failure."""
     table = model.Tables[testingtablename]
     with pytest.raises(Exception):
         model.refresh({table.Name: table.Partitions[0].Name + "fail"})

--- a/test/test_5column.py
+++ b/test/test_5column.py
@@ -1,5 +1,4 @@
-"""pytest for the column.py file. Covers the PyColumn and PyColumns classes.
-"""
+"""pytest for the column.py file. Covers the PyColumn and PyColumns classes."""
 from test.config import testing_parameters, testingtablename
 import pytest
 import pandas as pd
@@ -42,5 +41,6 @@ def test_query_every_column(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_dependencies(model):
+    """Tests execution of `PyColumn().get_dependencies()`."""
     df = model.Tables[0].Columns[1].get_dependencies()
     assert isinstance(df, pd.DataFrame)

--- a/test/test_6table.py
+++ b/test/test_6table.py
@@ -1,5 +1,4 @@
-"""pytest for the table.py file. Covers the PyTable and PyTables classes.
-"""
+"""pytest for the table.py file. Covers the PyTable and PyTables classes."""
 from test.config import testing_parameters, testingtablename
 import pytest
 import pandas as pd

--- a/test/test_7tabular_tracing.py
+++ b/test/test_7tabular_tracing.py
@@ -1,5 +1,4 @@
-"""pytest for the table.py file. Covers the PyTable and PyTables classes.
-"""
+"""pytest for the table.py file. Covers the PyTable and PyTables classes."""
 from test.config import testing_parameters, testingtablename
 import pytest
 import pytabular as p
@@ -15,8 +14,9 @@ def test_disconnect_for_trace(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_reconnect_update(model):
-    """This will test the `reconnect()` gets called in `update()`
-    of the `Base_Trace` class.
+    """This will test the `reconnect()`.
+
+    Gets called in `update()` of the `Base_Trace` class.
     """
     model.disconnect()
     model.Tables[testingtablename].refresh()

--- a/test/test_8bpa.py
+++ b/test/test_8bpa.py
@@ -1,3 +1,4 @@
+"""pytest for bpa."""
 import pytest
 import pytabular as p
 from test.config import testing_parameters
@@ -6,6 +7,7 @@ from os import getcwd
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_bpa(model):
+    """Testing execution of `model.analyze_bpa()`."""
     te2 = p.TabularEditor().exe
     bpa = p.BPA().location
     assert isinstance(model.analyze_bpa(te2, bpa), list)
@@ -13,9 +15,11 @@ def test_bpa(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_te2_custom_file_path(model):
+    """Testing TE2 Class."""
     assert isinstance(p.TabularEditor(getcwd()), p.TabularEditor)
 
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_bpa_custom_file_path(model):
+    """Testing BPA Class."""
     assert isinstance(p.BPA(getcwd()), p.BPA)

--- a/test/test_9custom.py
+++ b/test/test_9custom.py
@@ -1,6 +1,7 @@
 """These are tests I have for pretty janky features of PyTabular.
+
 These were designed selfishly for my own uses.
-So seperating out, to one day sunset and remove.
+So seperating out... To one day sunset and remove.
 """
 from test.config import testing_parameters, testingtablename
 import pytest
@@ -8,6 +9,7 @@ import pytest
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_backingup_table(model):
+    """Tests model.backup_table()."""
     model.backup_table(testingtablename)
     assert (
         len(
@@ -23,6 +25,7 @@ def test_backingup_table(model):
 
 @pytest.mark.parametrize("model", testing_parameters)
 def test_revert_table2(model):
+    """Tests model.revert_table()."""
     model.revert_table(testingtablename)
     assert (
         len(


### PR DESCRIPTION
- `flake8-docstrings` implementation to close out #39. Overhaul of docstrings to be compliant. Added `flake8-docstrings` to actions, so fix will be in place going forward.
- Typo in README.
- Find version function in `__init__`.
- Brought in more functions and classes to the documentation.

@Daandamhuis I finally figured out how to take a google docstring, keep it PEP8 compliant and have it look a lot better in the documentation. Screenshot is before and after of the changes to your `dict_to_markdown_table`.
![image](https://user-images.githubusercontent.com/17389000/218270761-a01a2908-fa92-4a68-97a1-a10978bfa517.png)